### PR TITLE
Pin Python version

### DIFF
--- a/.github/workflows/run-python-script.yaml
+++ b/.github/workflows/run-python-script.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.python-version


### PR DESCRIPTION
Pinning Python version to `3.12` to fix [error](https://github.com/OCHA-DAP/ds-nhc-forecast/actions/runs/15405025064/job/43345914418#step:4:144) in installing `pandas`.