### PR TITLE
Configure for multiple URLs

### DIFF
--- a/.github/workflows/run-python-script.yaml
+++ b/.github/workflows/run-python-script.yaml
@@ -31,7 +31,7 @@ jobs:
         STORAGE_ACCOUNT: ${{ secrets.STORAGE_ACCOUNT }}
         KEY: ${{ secrets.KEY }}
         GHP: ${{ secrets.GHP }}
-        GH_ACTION_URL: ${{ secrets.GH_ACTION_URL }}
+        GH_ACTION_TRIGGER_URLS: ${{ vars.GH_ACTION_TRIGGER_URLS }}
       run: |
         python run.py
     - name: Commit updated data bundle

--- a/nhc_forecast.py
+++ b/nhc_forecast.py
@@ -214,14 +214,14 @@ class NHCHurricaneForecast:
             container = os.environ["CONTAINER"]
             key = os.environ["KEY"]
             ghp = os.environ["GHP"]
-            ghaction_url = os.environ["GH_ACTION_URL"]
+            trigger_urls = os.environ["GH_ACTION_TRIGGER_URLS"].split(",")
             logger.info("Read the credentials from secrets.")
         except Exception:
             account = self.configuration["account"]
             container = self.configuration["container"]
             key = self.configuration["key"]
             ghp = self.configuration["ghp"]
-            ghaction_url = self.configuration["ghaction_url"]
+            trigger_urls = self.configuration["ghaction_url"]
             logger.info("Read the credentials from local secrets.")
 
         logger.info("Downloading historical forecasted_tracks...")
@@ -284,10 +284,11 @@ class NHCHurricaneForecast:
                         key=key,
                         data=observed_tracks_append.sort_values(['lastUpdate'], ascending=False))
 
-        try:
-            trigger_for_active_storms(ghaction_url, ghp)
-            logger.info("Successfully triggered Haiti Hurricanes action.")
-        except Exception:
-            logger.error("Failed to trigger Haiti Hurricanes action.")
+        for url in trigger_urls:
+            try:
+                trigger_for_active_storms(url, ghp)
+                logger.info(f"Successfully triggered url {url}")
+            except Exception:
+                logger.error(f"Failed to trigger url {url}")
 
         return dataset_names


### PR DESCRIPTION
Changing to allow multiple target URLs to be triggered when there's new forecast data. 

Also changing the URLs to be a variable since they're not sensitive and this makes it easier to debug. URLs have to be comma-separated, like: `https://api.github.com/repos/OCHA-DAP/ds-aa-cub-hurricanes/actions/workflows/01_run_forecast_data_ingestion.yml/dispatches,https://api.github.com/repos/OCHA-DAP/ds-aa-hti-hurricanes/actions/workflows/run_check_trigger.yml/dispatches` and stored in the variable `GH_ACTION_TRIGGER_URLS`.