### PR TITLE
Keep repo awake

### DIFF
--- a/.github/workflows/keep_awake.yml
+++ b/.github/workflows/keep_awake.yml
@@ -1,0 +1,27 @@
+name: Keep Repo Awake
+
+on:
+    schedule:
+        - cron: "0 12 * * 1" # At 12:00 PM UTC every Monday
+    workflow_dispatch:
+
+permissions:
+    contents: write
+
+jobs:
+    keep-awake:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v5
+          with:
+            ref: keep-awake
+
+        - name: Configure Git
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        - name: Commit and Push Changes
+          run: |
+            git commit --allow-empty -m "Keep repo awake [skip ci]"
+            git push origin keep-awake


### PR DESCRIPTION
Adding GitHub Action to make an empty commit to the `keep-awake` branch every Monday to prevent Actions from being automatically disabled.